### PR TITLE
fix(euler): Use mpmath for complex Float evaluation

### DIFF
--- a/sympy/functions/combinatorial/numbers.py
+++ b/sympy/functions/combinatorial/numbers.py
@@ -1127,6 +1127,12 @@ class euler(DefinedFunction):
                 return Integer(res)
         # Euler polynomials
         elif n.is_Number:
+            from sympy.core.numbers import Float
+            if x.has(Float):
+                from mpmath import mp
+                x_mp = mp.mpc(complex(x))
+                result = mp.eulerpoly(int(n), x_mp)
+                return Float(result.real) + I * Float(result.imag)
             return euler_poly(n, x)
 
     def _eval_rewrite_as_Sum(self, n, x=None, **kwargs):

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -426,6 +426,9 @@ def test_euler_polynomials():
     A = Float('-0.46237208575048694923364757452876131e8')  # from Maple
     B = euler(19, S.Pi).evalf(32)
     assert abs((A - B)/A) < 1e-31
+    z = Float(0.1) + Float(0.2)*I
+    expected = Float(-3126.54721663773) + I * Float(565.736261497056)
+    assert abs(euler(13, z) - expected) < 1e-10
 
 
 def test_euler_polynomial_rewrite():


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
