### PR TITLE
Enhance function_range for unsolvable derivatives

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -874,6 +874,7 @@ Kevin Hunter <hunteke@earlham.edu>
 Kevin McWhirter <klmcw@yahoo.com> klmcwhirter <klmcw@yahoo.com>
 Kevin Ventullo <kevin.ventullo@gmail.com>
 Khagesh Patel <khageshpatel93@gmail.com>
+Khalid Bagus <khalidbagus@gmail.com> khalidbagus <113655600+khalidbagus@users.noreply.github.com>
 Kibeom Kim <kk1674@nyu.edu>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
 Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>

--- a/sympy/calculus/util.py
+++ b/sympy/calculus/util.py
@@ -258,7 +258,12 @@ def function_range(f, symbol, domain):
                     vals += FiniteSet(f.subs(symbol, limit_point))
 
             critical_points = solveset(f.diff(symbol), symbol, interval)
-
+            if not critical_points.is_finite_set:
+                raise NotImplementedError(
+                    f"Unable to find explicit critical points for the derivative:\n\n  {f.diff(symbol)} = 0\n\n"
+                    "The computed set of critical points is non-finite, which may be due to the unsimplified form of "
+                    "the derivative (e.g. involving radicals or transcendental functions). "
+                )
             if not iterable(critical_points):
                 raise NotImplementedError(
                         'Unable to find critical points for {}'.format(f))


### PR DESCRIPTION
Simplify the check for critical points in function_range by using the is_finite_set property. Now, if solveset(f.diff(symbol), symbol, interval) does not return a FiniteSet, a NotImplementedError is raised with a clear explanation. This avoids excessive iteration over nested set types and prevents timeouts on complex derivative equations.

See #26518 for discussion.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
