### PR TITLE
Fix missing result in _discrete_log_trial_mul

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -1278,9 +1278,9 @@ def _discrete_log_trial_mul(n, a, b, order=None):
     a %= n
     b %= n
     if order is None:
-        order = n
+        order = n - 1
     x = 1
-    for i in range(order):
+    for i in range(order + 1):
         if x == a:
             return i
         x = x * b % n

--- a/sympy/ntheory/tests/test_residue.py
+++ b/sympy/ntheory/tests/test_residue.py
@@ -268,6 +268,7 @@ def test_residue():
     assert discrete_log(1, 0, 2) == 0
     raises(ValueError, lambda: discrete_log(-4, 1, 3))
     raises(ValueError, lambda: discrete_log(10, 3, 2))
+    assert discrete_log(10, 6, 2) == 4
     assert discrete_log(587, 2**9, 2) == 9
     assert discrete_log(2456747, 3**51, 3) == 51
     assert discrete_log(32942478, 11**127, 11) == 127


### PR DESCRIPTION
There was a off-by-one error when _discrete_log_trial_mul is called with an order

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
