### PR TITLE
Remove duplicate "NumPyPrinter" and add missing `"NumExprPrinter"` in…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -368,6 +368,7 @@ Au Huishan <huishan_au@outlook.com> Au Huishan <151558456+AkierRaee@users.norepl
 Au Huishan <huishan_au@outlook.com> pku2100094807 <2100094807@stu.pku.edu.cn>
 Augusto Borges <borges.augustoar@gmail.com>
 Austin Palmer <ap4000@nyu.edu> austin <ap4000@nyu.edu>
+Avasam <samuel.06@hotmail.com>
 Avi Shrivastava <shrivastavaavi123@gmail.com> avi <shrivastavaavi123@gmail.com>
 Avichal Dayal <avichal.dayal@gmail.com>
 Ayodeji Ige <ayodeji18@outlook.com>

--- a/sympy/printing/lambdarepr.py
+++ b/sympy/printing/lambdarepr.py
@@ -9,9 +9,9 @@ from sympy.core.sorting import default_sort_key
 __all__ = [
     'PythonCodePrinter',
     'MpmathPrinter',  # MpmathPrinter is published for backward compatibility
+    'NumExprPrinter',
     'NumPyPrinter',
     'LambdaPrinter',
-    'NumPyPrinter',
     'IntervalPrinter',
     'lambdarepr',
 ]


### PR DESCRIPTION
… `sympy.printing.lambdarepr.__all__`

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
