### PR TITLE
Ensure that math.trunc returns an int type

### DIFF
--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -368,7 +368,7 @@ class Expr(Basic, EvalfMixin):
         if not self.is_number:
             raise TypeError("Cannot truncate symbols and expressions")
         else:
-            return Integer(self)
+            return int(self)
 
     def __format__(self, format_spec: str):
         if self.is_number:


### PR DESCRIPTION
Per issue #26206, currently the return types of math functions on sympy objects are inconsistent. Since `math.floor` and `math.ceil` seems to be implemented in C, there's no easy way to change their behaviors. However, `math.trunc` simply calls the `__trunc__` function defined by the input object, so I changed its return type to a normal python int.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
