### PR TITLE
Fix Latex printing of logarithm with base

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -694,6 +694,7 @@ Himanshu <hs80941@gmail.com>
 Himanshu Ladia <hladia199811@gmail.com>
 Hiren Chalodiya <hirenchalodiya99@gmail.com>
 Hong Xu <hong@topbug.net>
+Hongyu Yang <brutusyhy@gmail.com> brutusyhy <142066452+brutusyhy@users.noreply.github.com>
 Hou-Rui <houruinus@gmail.com> Hou-Rui <13244639785@163.com>
 Huangduirong <huangduirong@huawei.com> Huangxiaodui <hdrong.42@163.com>
 Hubert Tsang <intsangity@gmail.com>

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1076,7 +1076,12 @@ class LatexPrinter(Printer):
 
     def _print_log(self, expr, exp=None):
         if not self._settings["ln_notation"]:
-            tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
+            if len(expr.args) == 2:
+                argument = self._print(expr.args[0])
+                base = self._print(expr.args[1])
+                tex = r"\log_%s{\left(%s \right)}" % (base, argument)
+            else:
+                tex = r"\log{\left(%s \right)}" % self._print(expr.args[0])
         else:
             tex = r"\ln{\left(%s \right)}" % self._print(expr.args[0])
 

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1409,6 +1409,9 @@ def test_latex_log():
     assert latex(pow(log(x), x), ln_notation=True) == \
         r"\ln{\left(x \right)}^{x}"
 
+    # issue #26897
+    assert latex(log(x, y, evaluate=False)) == r"\log_y{\left(x \right)}"
+
 
 def test_issue_3568():
     beta = Symbol(r'\beta')


### PR DESCRIPTION
Per issue #26897, previously latex(log(x, y, evaluate=False)) will return '\\log{\\left(x \\right)}', which discards the base. This fix ensures that if a base is provided, it will be included in the latex printing.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
