### PR TITLE
Mechanics linearizer update

### DIFF
--- a/sympy/physics/mechanics/functions.py
+++ b/sympy/physics/mechanics/functions.py
@@ -12,6 +12,7 @@ from sympy.core.function import AppliedUndef
 from sympy.physics.mechanics.inertia import (inertia as _inertia,
     inertia_of_point_mass as _inertia_of_point_mass)
 from sympy.utilities.exceptions import sympy_deprecation_warning
+from sympy.simplify._cse_diff import _forward_jacobian
 
 __all__ = ['linear_momentum',
            'angular_momentum',
@@ -733,3 +734,15 @@ def _parse_linear_solver(linear_solver):
     if callable(linear_solver):
         return linear_solver
     return lambda A, b: Matrix.solve(A, b, method=linear_solver)
+
+
+def _parse_jacobian_function(jacobian_function):
+    """Helper function to retrieve a specified jacobian function."""
+    if callable(jacobian_function):
+        return jacobian_function
+
+    elif jacobian_function == 'classic_jacobian':
+        return lambda expr, wrt: expr.jacobian(wrt)
+
+    elif jacobian_function == 'forward_jacobian':
+        return _forward_jacobian

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -11,7 +11,6 @@ from sympy.physics.mechanics.functions import (msubs, find_dynamicsymbols,
                                                _parse_linear_solver)
 from sympy.physics.mechanics.linearize import Linearizer
 from sympy.utilities.iterables import iterable
-from sympy.simplify._cse_diff import _forward_jacobian
 
 __all__ = ['KanesMethod']
 
@@ -535,7 +534,7 @@ class KanesMethod(_Methods):
         self._f_d = -(self._fr - nonMM)
         return fr_star
 
-    def to_linearizer(self, linear_solver='LU', jacobian_func=_forward_jacobian):
+    def to_linearizer(self, linear_solver='LU', jacobian_func='forward_jacobian'):
         """Returns an instance of the Linearizer class, initiated from the
         data in the KanesMethod class. This may be more desirable than using
         the linearize class method, as the Linearizer object will allow more
@@ -553,12 +552,13 @@ class KanesMethod(_Methods):
             ``'LU'`` which corresponds to SymPy's ``A.LUsolve(b)``.
             ``LUsolve()`` is fast to compute but will often result in
             divide-by-zero and thus ``nan`` results.
-        jacobian_func : callable
-            Function used to compute the Jacobian matrix. Default is
-            ``_forward_jacobian``. This function should have the signature
-            ``jacobian_func(expr, wrt)``, where ``expr`` is the expression to
-            differentiate and ``wrt`` is the iterable of variables with respect
-            to which to differentiate the expression.
+        jacobian_func : str, callable
+            Function used to compute the Jacobian matrix. If a string is
+            supplied, it should be a method between ``'forward_jacobian'``, or
+            ``'classic_jacobian'``. If a callable is supplied, it should
+            have the signature ``jacobian_func(expr, wrt)``, where ``expr``
+            is the expression to differentiate and ``wrt`` is the iterable of
+            variables with respect to which to differentiate the expression.
 
         Returns
         =======

--- a/sympy/physics/mechanics/kane.py
+++ b/sympy/physics/mechanics/kane.py
@@ -11,6 +11,7 @@ from sympy.physics.mechanics.functions import (msubs, find_dynamicsymbols,
                                                _parse_linear_solver)
 from sympy.physics.mechanics.linearize import Linearizer
 from sympy.utilities.iterables import iterable
+from sympy.simplify._cse_diff import _forward_jacobian
 
 __all__ = ['KanesMethod']
 
@@ -534,7 +535,7 @@ class KanesMethod(_Methods):
         self._f_d = -(self._fr - nonMM)
         return fr_star
 
-    def to_linearizer(self, linear_solver='LU'):
+    def to_linearizer(self, linear_solver='LU', jacobian_func=_forward_jacobian):
         """Returns an instance of the Linearizer class, initiated from the
         data in the KanesMethod class. This may be more desirable than using
         the linearize class method, as the Linearizer object will allow more
@@ -552,6 +553,12 @@ class KanesMethod(_Methods):
             ``'LU'`` which corresponds to SymPy's ``A.LUsolve(b)``.
             ``LUsolve()`` is fast to compute but will often result in
             divide-by-zero and thus ``nan`` results.
+        jacobian_func : callable
+            Function used to compute the Jacobian matrix. Default is
+            ``_forward_jacobian``. This function should have the signature
+            ``jacobian_func(expr, wrt)``, where ``expr`` is the expression to
+            differentiate and ``wrt`` is the iterable of variables with respect
+            to which to differentiate the expression.
 
         Returns
         =======
@@ -626,7 +633,7 @@ class KanesMethod(_Methods):
                 raise ValueError('Cannot have derivatives of specified \
                                  quantities when linearizing forcing terms.')
         return Linearizer(f_0, f_1, f_2, f_3, f_4, f_c, f_v, f_a, q, u, q_i,
-                q_d, u_i, u_d, r, linear_solver=linear_solver)
+                q_d, u_i, u_d, r, linear_solver=linear_solver, jacobian_func=jacobian_func)
 
     # TODO : Remove `new_method` after 1.1 has been released.
     def linearize(self, *, new_method=None, linear_solver='LU', **kwargs):

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -6,6 +6,7 @@ from sympy.physics.mechanics.functions import (
     find_dynamicsymbols, msubs, _f_list_parser, _validate_coordinates)
 from sympy.physics.mechanics.linearize import Linearizer
 from sympy.utilities.iterables import iterable
+from sympy.simplify._cse_diff import _forward_jacobian
 
 __all__ = ['LagrangesMethod']
 
@@ -290,7 +291,7 @@ class LagrangesMethod(_Methods):
             return self._qdots.col_join(self.forcing)
 
     def to_linearizer(self, q_ind=None, qd_ind=None, q_dep=None, qd_dep=None,
-                      linear_solver='LU'):
+                      linear_solver='LU', jacobian_func=_forward_jacobian):
         """Returns an instance of the Linearizer class, initiated from the data
         in the LagrangesMethod class. This may be more desirable than using the
         linearize class method, as the Linearizer object will allow more
@@ -313,6 +314,12 @@ class LagrangesMethod(_Methods):
             ``'LU'`` which corresponds to SymPy's ``A.LUsolve(b)``.
             ``LUsolve()`` is fast to compute but will often result in
             divide-by-zero and thus ``nan`` results.
+        jacobian_func : callable
+            Function used to compute the Jacobian matrix. Default is
+            ``_forward_jacobian``. This function should have the signature
+            ``jacobian_func(expr, wrt)``, where ``expr`` is the expression to
+            differentiate and ``wrt`` is the iterable of variables with respect
+            to which to differentiate the expression.
 
         Returns
         =======
@@ -370,7 +377,7 @@ class LagrangesMethod(_Methods):
                                  quantities when linearizing forcing terms.')
 
         return Linearizer(f_0, f_1, f_2, f_3, f_4, f_c, f_v, f_a, q, u, q_i,
-                          q_d, u_i, u_d, r, lams, linear_solver=linear_solver)
+                          q_d, u_i, u_d, r, lams, linear_solver=linear_solver, jacobian_func=jacobian_func)
 
     def linearize(self, q_ind=None, qd_ind=None, q_dep=None, qd_dep=None,
                   linear_solver='LU', **kwargs):

--- a/sympy/physics/mechanics/lagrange.py
+++ b/sympy/physics/mechanics/lagrange.py
@@ -6,7 +6,6 @@ from sympy.physics.mechanics.functions import (
     find_dynamicsymbols, msubs, _f_list_parser, _validate_coordinates)
 from sympy.physics.mechanics.linearize import Linearizer
 from sympy.utilities.iterables import iterable
-from sympy.simplify._cse_diff import _forward_jacobian
 
 __all__ = ['LagrangesMethod']
 
@@ -291,7 +290,7 @@ class LagrangesMethod(_Methods):
             return self._qdots.col_join(self.forcing)
 
     def to_linearizer(self, q_ind=None, qd_ind=None, q_dep=None, qd_dep=None,
-                      linear_solver='LU', jacobian_func=_forward_jacobian):
+                      linear_solver='LU', jacobian_func='forward_jacobian'):
         """Returns an instance of the Linearizer class, initiated from the data
         in the LagrangesMethod class. This may be more desirable than using the
         linearize class method, as the Linearizer object will allow more
@@ -314,12 +313,13 @@ class LagrangesMethod(_Methods):
             ``'LU'`` which corresponds to SymPy's ``A.LUsolve(b)``.
             ``LUsolve()`` is fast to compute but will often result in
             divide-by-zero and thus ``nan`` results.
-        jacobian_func : callable
-            Function used to compute the Jacobian matrix. Default is
-            ``_forward_jacobian``. This function should have the signature
-            ``jacobian_func(expr, wrt)``, where ``expr`` is the expression to
-            differentiate and ``wrt`` is the iterable of variables with respect
-            to which to differentiate the expression.
+        jacobian_func : str, callable
+            Function used to compute the Jacobian matrix. If a string is
+            supplied, it should be a method between ``'forward_jacobian'``, or
+            ``'classic_jacobian'``. If a callable is supplied, it should
+            have the signature ``jacobian_func(expr, wrt)``, where ``expr``
+            is the expression to differentiate and ``wrt`` is the iterable of
+            variables with respect to which to differentiate the expression.
 
         Returns
         =======

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -8,6 +8,7 @@ from sympy.physics.mechanics.functions import msubs, _parse_linear_solver
 
 from collections import namedtuple
 from collections.abc import Iterable
+from sympy.simplify._cse_diff import _forward_jacobian
 
 
 class Linearizer:
@@ -43,7 +44,7 @@ class Linearizer:
 
     def __init__(self, f_0, f_1, f_2, f_3, f_4, f_c, f_v, f_a, q, u, q_i=None,
                  q_d=None, u_i=None, u_d=None, r=None, lams=None,
-                 linear_solver='LU'):
+                 linear_solver='LU', jacobian_func=_forward_jacobian):
         """
         Parameters
         ==========
@@ -74,9 +75,16 @@ class Linearizer:
             ``'LU'`` which corresponds to SymPy's ``A.LUsolve(b)``.
             ``LUsolve()`` is fast to compute but will often result in
             divide-by-zero and thus ``nan`` results.
+        jacobian_func : callable
+            Function used to compute the Jacobian matrix. Default is
+            ``_forward_jacobian``. This function should have the signature
+            ``jacobian_func(expr, wrt)``, where ``expr`` is the expression to
+            differentiate and ``wrt`` is the iterable of variables with respect
+            to which to differentiate the expression.
 
         """
         self.linear_solver = _parse_linear_solver(linear_solver)
+        self.jacobian_func = jacobian_func
 
         # Generalized equation form
         self.f_0 = Matrix(f_0)
@@ -182,7 +190,7 @@ class Linearizer:
         # If there are configuration constraints (l > 0), form C_0 as normal.
         # If not, C_0 is I_(nxn). Note that this works even if n=0
         if l > 0:
-            f_c_jac_q = self.f_c.jacobian(self.q)
+            f_c_jac_q = self.jacobian_func(self.f_c, self.q)
             self._C_0 = (eye(n) - self._Pqd *
                          self.linear_solver(f_c_jac_q*self._Pqd,
                                             f_c_jac_q))*self._Pqi
@@ -192,10 +200,10 @@ class Linearizer:
         # If not, C_1 is 0, and C_2 is I_(oxo). Note that this works even if
         # o = 0.
         if m > 0:
-            f_v_jac_u = self.f_v.jacobian(self.u)
+            f_v_jac_u = self.jacobian_func(self.f_v, self.u)
             temp = f_v_jac_u * self._Pud
             if n != 0:
-                f_v_jac_q = self.f_v.jacobian(self.q)
+                f_v_jac_q = self.jacobian_func(self.f_v, self.q)
                 self._C_1 = -self._Pud * self.linear_solver(temp, f_v_jac_q)
             else:
                 self._C_1 = zeros(o, n)
@@ -213,45 +221,45 @@ class Linearizer:
         # Block Matrix Definitions. These are only defined if under certain
         # conditions. If undefined, an empty matrix is used instead
         if n != 0:
-            self._M_qq = self.f_0.jacobian(self._qd)
-            self._A_qq = -(self.f_0 + self.f_1).jacobian(self.q)
+            self._M_qq = self.jacobian_func(self.f_0, self._qd)
+            self._A_qq = -self.jacobian_func(self.f_0 + self.f_1, self.q)
         else:
             self._M_qq = Matrix()
             self._A_qq = Matrix()
         if n != 0 and m != 0:
-            self._M_uqc = self.f_a.jacobian(self._qd_dup)
-            self._A_uqc = -self.f_a.jacobian(self.q)
+            self._M_uqc = self.jacobian_func(self.f_a, self._qd_dup)
+            self._A_uqc = -self.jacobian_func(self.f_a, self.q)
         else:
             self._M_uqc = Matrix()
             self._A_uqc = Matrix()
         if n != 0 and o - m + k != 0:
-            self._M_uqd = self.f_3.jacobian(self._qd_dup)
-            self._A_uqd = -(self.f_2 + self.f_3 + self.f_4).jacobian(self.q)
+            self._M_uqd = self.jacobian_func(self.f_3, self._qd_dup)
+            self._A_uqd = -self.jacobian_func(self.f_2 + self.f_3 + self.f_4, self.q)
         else:
             self._M_uqd = Matrix()
             self._A_uqd = Matrix()
         if o != 0 and m != 0:
-            self._M_uuc = self.f_a.jacobian(self._ud)
-            self._A_uuc = -self.f_a.jacobian(self.u)
+            self._M_uuc = self.jacobian_func(self.f_a, self._ud)
+            self._A_uuc = -self.jacobian_func(self.f_a, self.u)
         else:
             self._M_uuc = Matrix()
             self._A_uuc = Matrix()
         if o != 0 and o - m + k != 0:
-            self._M_uud = self.f_2.jacobian(self._ud)
-            self._A_uud = -(self.f_2 + self.f_3).jacobian(self.u)
+            self._M_uud = self.jacobian_func(self.f_2, self._ud)
+            self._A_uud = -self.jacobian_func(self.f_2 + self.f_3, self.u)
         else:
             self._M_uud = Matrix()
             self._A_uud = Matrix()
         if o != 0 and n != 0:
-            self._A_qu = -self.f_1.jacobian(self.u)
+            self._A_qu = -self.jacobian_func(self.f_1, self.u)
         else:
             self._A_qu = Matrix()
         if k != 0 and o - m + k != 0:
-            self._M_uld = self.f_4.jacobian(self.lams)
+            self._M_uld = self.jacobian_func(self.f_4, self.lams)
         else:
             self._M_uld = Matrix()
         if s != 0 and o - m + k != 0:
-            self._B_u = -self.f_3.jacobian(self.r)
+            self._B_u = -self.jacobian_func(self.f_3, self.r)
         else:
             self._B_u = Matrix()
 

--- a/sympy/physics/mechanics/linearize.py
+++ b/sympy/physics/mechanics/linearize.py
@@ -4,11 +4,11 @@ from sympy import Matrix, eye, zeros
 from sympy.core.symbol import Dummy
 from sympy.utilities.iterables import flatten
 from sympy.physics.vector import dynamicsymbols
-from sympy.physics.mechanics.functions import msubs, _parse_linear_solver
+from sympy.physics.mechanics.functions import (msubs, _parse_linear_solver,
+                                               _parse_jacobian_function)
 
 from collections import namedtuple
 from collections.abc import Iterable
-from sympy.simplify._cse_diff import _forward_jacobian
 
 
 class Linearizer:
@@ -44,7 +44,7 @@ class Linearizer:
 
     def __init__(self, f_0, f_1, f_2, f_3, f_4, f_c, f_v, f_a, q, u, q_i=None,
                  q_d=None, u_i=None, u_d=None, r=None, lams=None,
-                 linear_solver='LU', jacobian_func=_forward_jacobian):
+                 linear_solver='LU', jacobian_func='forward_jacobian'):
         """
         Parameters
         ==========
@@ -75,16 +75,17 @@ class Linearizer:
             ``'LU'`` which corresponds to SymPy's ``A.LUsolve(b)``.
             ``LUsolve()`` is fast to compute but will often result in
             divide-by-zero and thus ``nan`` results.
-        jacobian_func : callable
-            Function used to compute the Jacobian matrix. Default is
-            ``_forward_jacobian``. This function should have the signature
-            ``jacobian_func(expr, wrt)``, where ``expr`` is the expression to
-            differentiate and ``wrt`` is the iterable of variables with respect
-            to which to differentiate the expression.
+        jacobian_func : str, callable
+            Function used to compute the Jacobian matrix. If a string is
+            supplied, it should be a method between ``'forward_jacobian'``, or
+            ``'classic_jacobian'``. If a callable is supplied, it should
+            have the signature ``jacobian_func(expr, wrt)``, where ``expr``
+            is the expression to differentiate and ``wrt`` is the iterable of
+            variables with respect to which to differentiate the expression.
 
         """
         self.linear_solver = _parse_linear_solver(linear_solver)
-        self.jacobian_func = jacobian_func
+        self.jacobian_func = _parse_jacobian_function(jacobian_func)
 
         # Generalized equation form
         self.f_0 = Matrix(f_0)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
