### PR TITLE
Fixed differentiation of PermuteDims objects

### DIFF
--- a/sympy/tensor/array/expressions/arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/arrayexpr_derivatives.py
@@ -176,9 +176,12 @@ def _(expr: ArrayAdd, x: Expr):
 
 @array_derive.register(PermuteDims)
 def _(expr: PermuteDims, x: Expr):
-    de = array_derive(expr.expr, x)
-    perm = [0, 1] + [i + 2 for i in expr.permutation.array_form]
-    return _permute_dims(de, perm)
+    derived_expr = array_derive(expr.expr, x)
+    rank_x = get_rank(x)
+    permutation_indices = list(range(rank_x)) + [
+        i + rank_x for i in expr.permutation.array_form
+    ]
+    return _permute_dims(derived_expr, permutation_indices)
 
 
 @array_derive.register(Reshape)

--- a/sympy/tensor/array/expressions/tests/test_arrayexpr_derivatives.py
+++ b/sympy/tensor/array/expressions/tests/test_arrayexpr_derivatives.py
@@ -4,7 +4,8 @@ from sympy.matrices.expressions.matexpr import MatrixSymbol
 from sympy.matrices.expressions.special import Identity
 from sympy.matrices.expressions.applyfunc import ElementwiseApplyFunction
 from sympy.tensor.array.expressions.array_expressions import ArraySymbol, ArrayTensorProduct, \
-    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, ArrayContraction, _permute_dims, Reshape
+    PermuteDims, ArrayDiagonal, ArrayElementwiseApplyFunc, ArrayContraction, _permute_dims, Reshape, \
+    ZeroArray
 from sympy.tensor.array.expressions.arrayexpr_derivatives import array_derive
 
 k = symbols("k")
@@ -76,3 +77,7 @@ def test_arrayexpr_derivatives1():
     cg = Reshape(A, (k**2,))
     res = array_derive(cg, A)
     assert res == Reshape(PermuteDims(ArrayTensorProduct(I, I), [0, 2, 1, 3]), (k, k, k**2))
+
+    cg = PermuteDims(A, (1, 0))
+    res = array_derive(cg, A1)
+    assert res == ZeroArray(3, 2, k, k, k)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
