### PR TITLE
make as_base_exp literal, like fraction

### DIFF
--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -798,14 +798,7 @@ class Pow(Expr):
                 return result
 
     def as_base_exp(self):
-        """Return base and exp of self.
-
-        Explanation
-        ===========
-
-        If base a Rational less than 1, then return 1/Rational, -exp.
-        If this extra processing is not needed, the base and exp
-        properties will give the raw arguments.
+        """Return a tuple of the arguments of self.
 
         Examples
         ========
@@ -813,17 +806,14 @@ class Pow(Expr):
         >>> from sympy import Pow, S
         >>> p = Pow(S.Half, 2, evaluate=False)
         >>> p.as_base_exp()
-        (2, -2)
+        (1/2, 2)
         >>> p.args
         (1/2, 2)
         >>> p.base, p.exp
         (1/2, 2)
 
         """
-        b, e = self.args
-        if b.is_Rational and b.p == 1 and b.q != 1:
-            return Integer(b.q), -e
-        return b, e
+        return self.args
 
     def _eval_adjoint(self):
         from sympy.functions.elementary.complexes import adjoint


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
